### PR TITLE
Improve concurrency safety and XML parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Use the default Xcode on the runner (Xcode 16 on macOS-14)
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 'latest-stable'
 
       - name: Cache SwiftPM
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16.4 (Swift 6.1)
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16.4'
+      # Use default Xcode on the runner (should be 16.x on macos-14)
 
       - name: Cache SwiftPM
         uses: actions/cache@v4
@@ -65,10 +62,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
 
-      - name: Swift version
+      - name: Toolchain info
         run: |
-          xcodebuild -version
-          swift --version
+          which xcodebuild || true
+          xcodebuild -version || true
+          sw_vers || true
+          which swift || true
+          swift --version || true
 
       - name: Build
         run: swift build -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16.0'
+      # Use the default Xcode on the runner (Xcode 16 on macOS-14)
 
       - name: Cache SwiftPM
         uses: actions/cache@v4
@@ -73,4 +70,3 @@ jobs:
 
       - name: Test
         run: swift test -v
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,16 @@ jobs:
 
   macos:
     name: macOS (Xcode 16)
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Use default Xcode on the runner (should be 16.x on macos-14)
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 'latest-stable'
 
       - name: Cache SwiftPM
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select latest stable Xcode
+      - name: Select Xcode 16.4 (Swift 6.1)
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 'latest-stable'
+          xcode-version: '16.4'
 
       - name: Cache SwiftPM
         uses: actions/cache@v4
@@ -66,7 +66,9 @@ jobs:
             ${{ runner.os }}-spm-
 
       - name: Swift version
-        run: swift --version
+        run: |
+          xcodebuild -version
+          swift --version
 
       - name: Build
         run: swift build -v

--- a/Sources/ArxivSwift/ArxivClient.swift
+++ b/Sources/ArxivSwift/ArxivClient.swift
@@ -3,7 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 /// The main client for interacting with the arXiv API
-public final class ArxivClient: @unchecked Sendable {
+public actor ArxivClient {
     
     // MARK: - Properties
     

--- a/Sources/ArxivSwift/ArxivError.swift
+++ b/Sources/ArxivSwift/ArxivError.swift
@@ -127,7 +127,9 @@ public enum ArxivError: Error, LocalizedError, Equatable {
     public static func == (lhs: ArxivError, rhs: ArxivError) -> Bool {
         switch (lhs, rhs) {
         case (.networkError(let lhsError), .networkError(let rhsError)):
-            return lhsError.localizedDescription == rhsError.localizedDescription
+            let lhs = lhsError as NSError
+            let rhs = rhsError as NSError
+            return lhs.domain == rhs.domain && lhs.code == rhs.code
         case (.invalidURL(let lhsURL), .invalidURL(let rhsURL)):
             return lhsURL == rhsURL
         case (.parsingError(let lhsMessage), .parsingError(let rhsMessage)):

--- a/Sources/ArxivSwift/ArxivQuery.swift
+++ b/Sources/ArxivSwift/ArxivQuery.swift
@@ -10,7 +10,7 @@ import Foundation
 /// let query = ArxivQuery()
 ///     .sort(by: .submittedDate, order: .descending)
 /// ```
-public enum SortBy: String, CaseIterable {
+public enum SortBy: String, CaseIterable, Sendable {
     /// Sort by relevance to the search query (default)
     case relevance = "relevance"
     /// Sort by the date the paper was last updated
@@ -28,7 +28,7 @@ public enum SortBy: String, CaseIterable {
 /// let query = ArxivQuery()
 ///     .sort(by: .submittedDate, order: .ascending) // Oldest first
 /// ```
-public enum SortOrder: String, CaseIterable {
+public enum SortOrder: String, CaseIterable, Sendable {
     /// Sort in ascending order (oldest first for dates, lowest relevance first)
     case ascending = "ascending"
     /// Sort in descending order (newest first for dates, highest relevance first)
@@ -46,7 +46,7 @@ public enum SortOrder: String, CaseIterable {
 ///     .addSearch(field: .title, value: "neural networks")
 ///     .addSearch(field: .category, value: "cs.AI")
 /// ```
-public enum QueryField: String, CaseIterable {
+public enum QueryField: String, CaseIterable, Sendable {
     /// Search in paper titles
     case title = "ti"
     /// Search in author names
@@ -101,7 +101,7 @@ public enum QueryField: String, CaseIterable {
 ///
 /// All methods return a new `ArxivQuery` instance, allowing for method chaining
 /// while maintaining immutability.
-public struct ArxivQuery {
+public struct ArxivQuery: Sendable {
     private var searchTerms: [String] = []
     private var start: Int = 0
     private var maxResults: Int = 10
@@ -163,7 +163,7 @@ public struct ArxivQuery {
     /// Build the URL query string for the arXiv API
     /// - Returns: The complete URL string for the API request
     internal func buildURLString() -> String {
-        let baseURL = "http://export.arxiv.org/api/query"
+        let baseURL = "https://export.arxiv.org/api/query"
         var components = URLComponents(string: baseURL)!
         
         var queryItems: [URLQueryItem] = []

--- a/Sources/ArxivSwift/XMLParserDelegate.swift
+++ b/Sources/ArxivSwift/XMLParserDelegate.swift
@@ -89,66 +89,68 @@ internal class ArxivXMLParserDelegate: NSObject, XMLParserDelegate {
     }
     
     func parser(_ parser: XMLParser, foundCharacters string: String) {
-        currentText += string.trimmingCharacters(in: .whitespacesAndNewlines)
+        currentText += string
     }
-    
+
     func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         defer {
             currentElement = ""
             currentText = ""
         }
-        
+
         guard let currentEntry = currentEntry else {
             return
         }
-        
+
+        let text = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+
         switch elementName {
         case "entry":
             if let entry = currentEntry.build() {
                 entries.append(entry)
             }
             self.currentEntry = nil
-            
+
         case "id":
             // Extract arXiv ID from the full URL
-            let arxivId = extractArxivId(from: currentText)
+            let arxivId = extractArxivId(from: text)
             currentEntry.setId(arxivId)
-            
+
         case "title":
-            currentEntry.setTitle(currentText)
-            
+            currentEntry.setTitle(text)
+
         case "summary":
-            currentEntry.setAbstract(currentText)
-            
+            currentEntry.setAbstract(text)
+
         case "published":
-            if let date = parseDate(currentText) {
+            if let date = parseDate(text) {
                 currentEntry.setPublished(date)
             }
-            
+
         case "updated":
-            if let date = parseDate(currentText) {
+            if let date = parseDate(text) {
                 currentEntry.setUpdated(date)
             }
-            
+
         case "name":
             // This is an author name within an <author> element
             if currentElement == "name" {
-                let author = ArxivAuthor(name: currentText)
+                let author = ArxivAuthor(name: text)
                 currentEntry.addAuthor(author)
             }
-            
+
         case "arxiv:comment":
-            currentEntry.setComment(currentText)
-            
+            currentEntry.setComment(text)
+
         case "arxiv:journal_ref":
-            currentEntry.setJournalReference(currentText)
-            
+            currentEntry.setJournalReference(text)
+
         case "arxiv:doi":
-            currentEntry.setDoi(currentText)
-            
+            currentEntry.setDoi(text)
+
         case "arxiv:report_no":
-            currentEntry.setReportNumber(currentText)
-            
+            currentEntry.setReportNumber(text)
+
         case "arxiv:primary_category":
             // This is handled in didStartElement with attributes
             break


### PR DESCRIPTION
## Summary
- convert `ArxivClient` into an actor for safer concurrent use
- switch arXiv API requests to HTTPS and mark query types as `Sendable`
- compare network errors by domain and code instead of localized descriptions
- preserve whitespace in XML parsing by deferring string trimming

## Testing
- `swift test` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e30bd4f8832c91776c62d9fd0068