### PR TITLE
Refactor ArxivClient tests to use mocked URL responses

### DIFF
--- a/Tests/ArxivSwiftTests/ArxivClientTests.swift
+++ b/Tests/ArxivSwiftTests/ArxivClientTests.swift
@@ -1,173 +1,209 @@
+import Foundation
+#if os(Linux)
+import FoundationNetworking
+#endif
 import Testing
 @testable import ArxivSwift
 
 @Suite("ArxivClient Tests")
 struct ArxivClientTests {
-    
-    let client: ArxivClient
-    
-    init() {
-        client = ArxivClient()
-    }
-    
-    @Test("Get entries with simple query")
-    func getEntriesWithSimpleQuery() async throws {
+
+    private let sampleFeedXML = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <id>http://arxiv.org/abs/1234.5678v1</id>
+        <updated>2024-01-01T00:00:00Z</updated>
+        <published>2024-01-01T00:00:00Z</published>
+        <title>Sample Paper One</title>
+        <summary>First abstract text.</summary>
+        <author>
+          <name>Alice Example</name>
+        </author>
+        <category term="cs.AI" scheme="http://arxiv.org/schemas/atom"/>
+      </entry>
+      <entry>
+        <id>http://arxiv.org/abs/2345.6789v2</id>
+        <updated>2024-01-02T12:30:00Z</updated>
+        <published>2024-01-02T12:30:00Z</published>
+        <title>Sample Paper Two</title>
+        <summary>Second abstract text.</summary>
+        <author>
+          <name>Bob Example</name>
+        </author>
+        <category term="cs.AI" scheme="http://arxiv.org/schemas/atom"/>
+        <category term="stat.ML" scheme="http://arxiv.org/schemas/atom"/>
+      </entry>
+    </feed>
+    """
+
+    private let singleEntryXML = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <id>http://arxiv.org/abs/9999.0001v1</id>
+        <updated>2024-02-10T08:00:00Z</updated>
+        <published>2024-02-10T08:00:00Z</published>
+        <title>Attention Still Matters</title>
+        <summary>Revisiting attention mechanisms.</summary>
+        <author>
+          <name>Casey Example</name>
+        </author>
+        <category term="cs.CL" scheme="http://arxiv.org/schemas/atom"/>
+      </entry>
+    </feed>
+    """
+
+    @Test("Get entries parses feed without network access")
+    func getEntriesParsesFeed() async throws {
+        let data = try #require(sampleFeedXML.data(using: .utf8))
+        var capturedURL: URL?
+
         let query = ArxivQuery()
             .addSearch(field: .category, value: "cs.AI")
-            .maxResults(3)
+            .maxResults(2)
             .sort(by: .submittedDate, order: .descending)
-        
+
+        let expectedURL = query.buildURLString()
+        let client = makeClient()
+        MockURLProtocol.stub(
+            urlString: expectedURL,
+            statusCode: 200,
+            headers: ["Content-Type": "application/atom+xml"],
+            data: data
+        ) { request in
+            capturedURL = request.url
+        }
+
         let entries = try await client.getEntries(for: query)
-        
-        #expect(entries.count > 0)
-        #expect(entries.count <= 3)
-        
-        // Verify that all entries have required fields
-        for entry in entries {
-            #expect(!entry.id.isEmpty)
-            #expect(!entry.title.isEmpty)
-            #expect(!entry.abstract.isEmpty)
-            #expect(entry.authors.count > 0)
-            
-            // Check that the entry belongs to cs.AI category
-            #expect(entry.belongsToCategory("cs.AI"))
+
+        #expect(entries.count == 2)
+        #expect(entries[0].id == "1234.5678v1")
+        #expect(entries[0].authors.first?.name == "Alice Example")
+        #expect(entries[1].categories.map(\.term) == ["cs.AI", "stat.ML"])
+        #expect(capturedURL?.absoluteString.contains("search_query=cat:cs.AI") == true)
+        #expect(capturedURL?.absoluteString.contains("max_results=2") == true)
+    }
+
+    @Test("HTTP errors are surfaced as ArxivError")
+    func getEntriesHandlesHTTPError() async {
+        let query = ArxivQuery().addSearch(field: .all, value: "test")
+        let expectedURL = query.buildURLString()
+        var capturedURL: URL?
+        let client = makeClient()
+        MockURLProtocol.stub(
+            urlString: expectedURL,
+            statusCode: 500,
+            data: Data("Server Error".utf8)
+        ) { request in
+            capturedURL = request.url
         }
-    }
-    
-    @Test("Search by author")
-    func searchByAuthor() async throws {
-        // Search for a well-known author in computer science
-        let entries = try await client.searchByAuthor("Yann LeCun", maxResults: 2)
-        
-        #expect(entries.count > 0)
-        #expect(entries.count <= 2)
-        
-        // Verify that at least one entry has the author
-        let hasAuthor = entries.contains { entry in
-            entry.authors.contains { author in
-                author.name.lowercased().contains("lecun")
-            }
-        }
-        #expect(hasAuthor, "Should find at least one paper by the searched author")
-    }
-    
-    @Test("Search by title")
-    func searchByTitle() async throws {
-        let entries = try await client.searchByTitle("neural network", maxResults: 2)
-        
-        #expect(entries.count > 0)
-        #expect(entries.count <= 2)
-        
-        // Verify that at least one entry has "neural" or "network" in the title
-        let hasRelevantTitle = entries.contains { entry in
-            let title = entry.title.lowercased()
-            return title.contains("neural") || title.contains("network")
-        }
-        #expect(hasRelevantTitle, "Should find papers with relevant titles")
-    }
-    
-    @Test("Search by category")
-    func searchByCategory() async throws {
-        let entries = try await client.searchByCategory("math.NT", maxResults: 2)
-        
-        #expect(entries.count > 0)
-        #expect(entries.count <= 2)
-        
-        // Verify that all entries belong to the math.NT category
-        for entry in entries {
-            #expect(entry.belongsToCategory("math.NT"))
-        }
-    }
-    
-    @Test("Search by abstract")
-    func searchByAbstract() async throws {
-        let entries = try await client.searchByAbstract("machine learning", maxResults: 2)
-        
-        #expect(entries.count > 0)
-        #expect(entries.count <= 2)
-        
-        // Verify that at least one entry has "machine" or "learning" in the abstract
-        let hasRelevantAbstract = entries.contains { entry in
-            let abstract = entry.abstract.lowercased()
-            return abstract.contains("machine") || abstract.contains("learning")
-        }
-        #expect(hasRelevantAbstract, "Should find papers with relevant abstracts")
-    }
-    
-    @Test("Get latest entries")
-    func getLatestEntries() async throws {
-        // Use a more specific query that's more likely to return results
-        let query = ArxivQuery()
-            .addSearch(field: .category, value: "cs.AI")
-            .maxResults(3)
-            .sort(by: .submittedDate, order: .descending)
-        
-        let entries = try await client.getEntries(for: query)
-        
-        #expect(entries.count > 0)
-        #expect(entries.count <= 3)
-        
-        // Just verify we got valid entries
-        for entry in entries {
-            #expect(!entry.id.isEmpty)
-            #expect(!entry.title.isEmpty)
-            #expect(!entry.abstract.isEmpty)
-            #expect(entry.authors.count > 0)
-        }
-    }
-    
-    @Test("Get latest entries with category")
-    func getLatestEntriesWithCategory() async throws {
-        let entries = try await client.getLatestEntries(maxResults: 2, category: "cs.LG")
-        
-        #expect(entries.count > 0)
-        #expect(entries.count <= 2)
-        
-        // Verify that all entries belong to the cs.LG category
-        for entry in entries {
-            #expect(entry.belongsToCategory("cs.LG"))
-        }
-    }
-    
-    @Test("Get entry by ID")
-    func getEntryById() async throws {
-        // Use a well-known arXiv paper ID
-        let arxivId = "1706.03762" // "Attention Is All You Need" paper
-        
-        let entry = try await client.getEntry(by: arxivId)
-        
-        #expect(entry.id.contains(arxivId))
-        #expect(!entry.title.isEmpty)
-        #expect(!entry.abstract.isEmpty)
-        #expect(entry.authors.count > 0)
-    }
-    
-    @Test("Error handling with invalid query")
-    func errorHandlingWithInvalidQuery() async {
-        let query = ArxivQuery()
-            .addSearch(field: .id, value: "nonexistent-id-12345")
-            .maxResults(1)
-        
+
         do {
-            let entries = try await client.getEntries(for: query)
-            // If we get here, the query returned results (which is unexpected but not an error)
-            #expect(entries.count == 0, "Should return empty results for nonexistent ID")
+            _ = try await client.getEntries(for: query)
+            Issue.record("Expected getEntries to throw for HTTP 500")
+        } catch let error as ArxivError {
+            if case .httpError(let code) = error {
+                #expect(code == 500)
+            } else {
+                Issue.record("Expected httpError, got \(error)")
+            }
         } catch {
-            // This is also acceptable - some invalid queries might throw errors
-            #expect(error is ArxivError)
+            Issue.record("Expected ArxivError, got \(error)")
         }
+
+        #expect(capturedURL?.absoluteString == expectedURL)
     }
-    
+
+    @Test("Empty responses surface noData error")
+    func getEntriesHandlesEmptyResponse() async {
+        let query = ArxivQuery().start(5)
+        let expectedURL = query.buildURLString()
+        var capturedURL: URL?
+        let client = makeClient()
+        MockURLProtocol.stub(
+            urlString: expectedURL,
+            statusCode: 200,
+            data: Data()
+        ) { request in
+            capturedURL = request.url
+        }
+
+        do {
+            _ = try await client.getEntries(for: query)
+            Issue.record("Expected getEntries to throw for empty data")
+        } catch let error as ArxivError {
+            #expect(error == .noData)
+        } catch {
+            Issue.record("Expected ArxivError.noData, got \(error)")
+        }
+
+        #expect(capturedURL?.absoluteString == expectedURL)
+    }
+
+    @Test("Invalid XML surfaces parsing error")
+    func getEntriesHandlesInvalidXML() async {
+        let query = ArxivQuery().start(10)
+        let expectedURL = query.buildURLString()
+        var capturedURL: URL?
+        let client = makeClient()
+        MockURLProtocol.stub(
+            urlString: expectedURL,
+            statusCode: 200,
+            data: Data("not xml".utf8)
+        ) { request in
+            capturedURL = request.url
+        }
+
+        do {
+            _ = try await client.getEntries(for: query)
+            Issue.record("Expected getEntries to throw for invalid XML")
+        } catch let error as ArxivError {
+            if case .parsingError = error {
+                // Expected path
+            } else {
+                Issue.record("Expected parsingError, got \(error)")
+            }
+        } catch {
+            Issue.record("Expected ArxivError.parsingError, got \(error)")
+        }
+
+        #expect(capturedURL?.absoluteString == expectedURL)
+    }
+
+    @Test("getEntry(by:) returns the first parsed entry")
+    func getEntryById() async throws {
+        let data = try #require(singleEntryXML.data(using: .utf8))
+        var capturedURL: URL?
+
+        let queryURL = ArxivQuery().addSearch(field: .id, value: "9999.0001").maxResults(1).buildURLString()
+        let client = makeClient()
+        MockURLProtocol.stub(
+            urlString: queryURL,
+            statusCode: 200,
+            data: data
+        ) { request in
+            capturedURL = request.url
+        }
+
+        let entry = try await client.getEntry(by: "9999.0001")
+
+        #expect(entry.id == "9999.0001v1")
+        #expect(entry.title == "Attention Still Matters")
+        #expect(entry.authors.first?.name == "Casey Example")
+        #expect(capturedURL?.absoluteString.contains("search_query=id:9999.0001") == true)
+        #expect(capturedURL?.absoluteString.contains("max_results=1") == true)
+    }
+
     @Test("Convenience extensions")
     func convenienceExtensions() {
-        // Test ArxivEntry convenience methods
         let author1 = ArxivAuthor(name: "John Doe")
         let author2 = ArxivAuthor(name: "Jane Smith")
         let author3 = ArxivAuthor(name: "Bob Johnson")
-        
+
         let category = ArxivCategory(term: "cs.AI")
         let link = ArxivLink(href: "http://example.com/paper.pdf", title: "pdf")
-        
+
         let entry = ArxivEntry(
             id: "2301.12345v1",
             title: "Test Paper",
@@ -179,19 +215,67 @@ struct ArxivClientTests {
             categories: [category],
             links: [link]
         )
-        
-        // Test formatted authors
+
         #expect(entry.formattedAuthors == "John Doe, Jane Smith, and Bob Johnson")
-        
-        // Test clean arXiv ID
         #expect(entry.cleanArxivId == "2301.12345")
-        
-        // Test category methods
         #expect(entry.belongsToCategory("cs.AI"))
         #expect(!entry.belongsToCategory("math.NT"))
-        
-        // Test author name parsing
         #expect(author1.firstName == "John")
         #expect(author1.lastName == "Doe")
     }
-} 
+
+    // MARK: - Helpers
+
+    private func makeClient() -> ArxivClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        return ArxivClient(session: session)
+    }
+}
+
+private final class MockURLProtocol: URLProtocol {
+    private struct Stub {
+        let response: HTTPURLResponse
+        let data: Data
+        let observer: ((URLRequest) -> Void)?
+    }
+
+    nonisolated(unsafe) private static var stubs: [String: Stub] = [:]
+
+    static func stub(
+        urlString: String,
+        statusCode: Int,
+        headers: [String: String]? = nil,
+        data: Data,
+        observer: ((URLRequest) -> Void)? = nil
+    ) {
+        guard let url = URL(string: urlString) else { return }
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: headers)!
+        stubs[urlString] = Stub(response: response, data: data, observer: observer)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let urlString = request.url?.absoluteString,
+              let stub = Self.stubs.removeValue(forKey: urlString) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+
+        stub.observer?(request)
+
+        client?.urlProtocol(self, didReceive: stub.response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Summary
- replace the ArxivClient integration tests that hit the live API with URLProtocol-based mocks
- verify success, HTTP error, empty payload, invalid XML, and ID lookups without relying on the network

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_690b37d911ec832c965658540ddc18c9